### PR TITLE
Converting complicated matmul to einsum

### DIFF
--- a/core/model.py
+++ b/core/model.py
@@ -16,7 +16,7 @@ import tensorflow as tf
 
 
 class CaptionGenerator(object):
-    def __init__(self, word_to_idx, dim_feature=[196, 512], dim_embed=512, dim_hidden=1024, n_time_step=16, 
+    def __init__(self, word_to_idx, dim_feature=[196, 512], dim_embed=512, dim_hidden=1024, n_time_step=16,
                   prev2out=True, ctx2out=True, alpha_c=0.0, selector=True, dropout=True):
         """
         Args:
@@ -24,14 +24,14 @@ class CaptionGenerator(object):
             dim_feature: (optional) Dimension of vggnet19 conv5_3 feature vectors.
             dim_embed: (optional) Dimension of word embedding.
             dim_hidden: (optional) Dimension of all hidden state.
-            n_time_step: (optional) Time step size of LSTM. 
+            n_time_step: (optional) Time step size of LSTM.
             prev2out: (optional) previously generated word to hidden state. (see Eq (7) for explanation)
             ctx2out: (optional) context to hidden state (see Eq (7) for explanation)
             alpha_c: (optional) Doubly stochastic regularization coefficient. (see Section (4.2.1) for explanation)
             selector: (optional) gating scalar for context vector. (see Section (4.2.1) for explanation)
             dropout: (optional) If true then dropout layer is added.
         """
-        
+
         self.word_to_idx = word_to_idx
         self.idx_to_word = {i: w for w, i in word_to_idx.iteritems()}
         self.prev2out = prev2out
@@ -55,7 +55,7 @@ class CaptionGenerator(object):
         # Place holder for features and captions
         self.features = tf.placeholder(tf.float32, [None, self.L, self.D])
         self.captions = tf.placeholder(tf.int32, [None, self.T + 1])
-    
+
     def _get_initial_lstm(self, features):
         with tf.variable_scope('initial_lstm'):
             features_mean = tf.reduce_mean(features, 1)
@@ -78,9 +78,7 @@ class CaptionGenerator(object):
     def _project_features(self, features):
         with tf.variable_scope('project_features'):
             w = tf.get_variable('w', [self.D, self.D], initializer=self.weight_initializer)
-            features_flat = tf.reshape(features, [-1, self.D])
-            features_proj = tf.matmul(features_flat, w)  
-            features_proj = tf.reshape(features_proj, [-1, self.L, self.D])
+            features_proj = tf.einsum('ijk,kl->ijl', features, w)
             return features_proj
 
     def _attention_layer(self, features, features_proj, h, reuse=False):
@@ -90,19 +88,19 @@ class CaptionGenerator(object):
             w_att = tf.get_variable('w_att', [self.D, 1], initializer=self.weight_initializer)
 
             h_att = tf.nn.relu(features_proj + tf.expand_dims(tf.matmul(h, w), 1) + b)    # (N, L, D)
-            out_att = tf.reshape(tf.matmul(tf.reshape(h_att, [-1, self.D]), w_att), [-1, self.L])   # (N, L)
-            alpha = tf.nn.softmax(out_att)  
+            out_att = tf.einsum('ijk,kl->ij', h_att, w_att)     # (N, L)
+            alpha = tf.nn.softmax(out_att)
             context = tf.reduce_sum(features * tf.expand_dims(alpha, 2), 1, name='context')   #(N, D)
             return context, alpha
-  
+
     def _selector(self, context, h, reuse=False):
         with tf.variable_scope('selector', reuse=reuse):
             w = tf.get_variable('w', [self.H, 1], initializer=self.weight_initializer)
             b = tf.get_variable('b', [1], initializer=self.const_initializer)
             beta = tf.nn.sigmoid(tf.matmul(h, w) + b, 'beta')    # (N, 1)
-            context = tf.mul(beta, context, name='selected_context') 
+            context = tf.mul(beta, context, name='selected_context')
             return context, beta
-  
+
     def _decode_lstm(self, x, h, context, dropout=False, reuse=False):
         with tf.variable_scope('logits', reuse=reuse):
             w_h = tf.get_variable('w_h', [self.H, self.M], initializer=self.weight_initializer)
@@ -126,9 +124,9 @@ class CaptionGenerator(object):
                 h_logits = tf.nn.dropout(h_logits, 0.5)
             out_logits = tf.matmul(h_logits, w_out) + b_out
             return out_logits
-        
+
     def _batch_norm(self, x, mode='train', name=None):
-        return tf.contrib.layers.batch_norm(inputs=x, 
+        return tf.contrib.layers.batch_norm(inputs=x,
                                             decay=0.95,
                                             center=True,
                                             scale=True,
@@ -141,14 +139,14 @@ class CaptionGenerator(object):
         captions = self.captions
         batch_size = tf.shape(features)[0]
 
-        captions_in = captions[:, :self.T]      
-        captions_out = captions[:, 1:]  
+        captions_in = captions[:, :self.T]
+        captions_out = captions[:, 1:]
         mask = tf.to_float(tf.not_equal(captions_out, self._null))
-        
-        
+
+
         # batch normalize feature vectors
         features = self._batch_norm(features, mode='train', name='conv_features')
-        
+
         c, h = self._get_initial_lstm(features=features)
         x = self._word_embedding(inputs=captions_in)
         features_proj = self._project_features(features=features)
@@ -162,28 +160,28 @@ class CaptionGenerator(object):
             alpha_list.append(alpha)
 
             if self.selector:
-                context, beta = self._selector(context, h, reuse=(t!=0)) 
+                context, beta = self._selector(context, h, reuse=(t!=0))
 
             with tf.variable_scope('lstm', reuse=(t!=0)):
                 _, (c, h) = lstm_cell(inputs=tf.concat(1, [x[:,t,:], context]), state=[c, h])
 
             logits = self._decode_lstm(x[:,t,:], h, context, dropout=self.dropout, reuse=(t!=0))
             loss += tf.reduce_sum(tf.nn.sparse_softmax_cross_entropy_with_logits(logits, captions_out[:, t]) * mask[:, t])
-           
+
         if self.alpha_c > 0:
             alphas = tf.transpose(tf.pack(alpha_list), (1, 0, 2))     # (N, T, L)
             alphas_all = tf.reduce_sum(alphas, 1)      # (N, L)
-            alpha_reg = self.alpha_c * tf.reduce_sum((16./196 - alphas_all) ** 2)     
+            alpha_reg = self.alpha_c * tf.reduce_sum((16./196 - alphas_all) ** 2)
             loss += alpha_reg
 
         return loss / tf.to_float(batch_size)
 
     def build_sampler(self, max_len=20):
         features = self.features
-        
+
         # batch normalize feature vectors
         features = self._batch_norm(features, mode='test', name='conv_features')
-        
+
         c, h = self._get_initial_lstm(features=features)
         features_proj = self._project_features(features=features)
 
@@ -196,21 +194,21 @@ class CaptionGenerator(object):
             if t == 0:
                 x = self._word_embedding(inputs=tf.fill([tf.shape(features)[0]], self._start))
             else:
-                x = self._word_embedding(inputs=sampled_word, reuse=True)  
-          
+                x = self._word_embedding(inputs=sampled_word, reuse=True)
+
             context, alpha = self._attention_layer(features, features_proj, h, reuse=(t!=0))
             alpha_list.append(alpha)
 
             if self.selector:
-                context, beta = self._selector(context, h, reuse=(t!=0)) 
+                context, beta = self._selector(context, h, reuse=(t!=0))
                 beta_list.append(beta)
 
             with tf.variable_scope('lstm', reuse=(t!=0)):
                 _, (c, h) = lstm_cell(inputs=tf.concat(1, [x, context]), state=[c, h])
 
             logits = self._decode_lstm(x, h, context, reuse=(t!=0))
-            sampled_word = tf.argmax(logits, 1)       
-            sampled_word_list.append(sampled_word)     
+            sampled_word = tf.argmax(logits, 1)
+            sampled_word_list.append(sampled_word)
 
         alphas = tf.transpose(tf.pack(alpha_list), (1, 0, 2))     # (N, T, L)
         betas = tf.transpose(tf.squeeze(beta_list), (1, 0))    # (N, T)


### PR DESCRIPTION
`tf.einsum` provides a pretty way to do tensor multiplications past 2D. Simplifies the code but only slightly, mostly increases readability.
